### PR TITLE
Add DeepL translation provider support

### DIFF
--- a/src/common/components/Settings.tsx
+++ b/src/common/components/Settings.tsx
@@ -1339,6 +1339,7 @@ function ProviderSelector({ value, onChange, hasPromotion }: IProviderSelectorPr
               { label: 'Moonshot', id: 'Moonshot' },
               { label: 'Groq', id: 'Groq' },
               { label: 'DeepSeek', id: 'DeepSeek' },
+              { label: 'DeepL', id: 'DeepL' },
           ] as {
               label: string
               id: Provider
@@ -1356,6 +1357,7 @@ function ProviderSelector({ value, onChange, hasPromotion }: IProviderSelectorPr
               { label: 'Moonshot', id: 'Moonshot' },
               { label: 'Groq', id: 'Groq' },
               { label: 'DeepSeek', id: 'DeepSeek' },
+              { label: 'DeepL', id: 'DeepL' },
           ] as {
               label: string
               id: Provider
@@ -2464,6 +2466,49 @@ export function InnerSettings({
                                     apiKey={values.deepSeekAPIKey}
                                     onBlur={onBlur}
                                 />
+                            </FormItem>
+                        </div>
+                        <div
+                            style={{
+                                display: values.provider === 'DeepL' ? 'block' : 'none',
+                            }}
+                        >
+                            <FormItem
+                                required={values.provider === 'DeepL'}
+                                name='deeplAPIKey'
+                                label='DeepL API Key'
+                                caption={
+                                    <div>
+                                        {t('Go to the')}{' '}
+                                        <a
+                                            target='_blank'
+                                            href='https://www.deepl.com/account/summary'
+                                            rel='noreferrer'
+                                            style={linkStyle}
+                                        >
+                                            DeepL Account
+                                        </a>{' '}
+                                        {t('to get your API Key.')}
+                                    </div>
+                                }
+                            >
+                                <Input autoFocus type='password' size='compact' onBlur={onBlur} />
+                            </FormItem>
+                            <FormItem
+                                required={values.provider === 'DeepL'}
+                                name='deeplAPIURL'
+                                label={t('API URL')}
+                                caption={t('Generally, there is no need to modify this item.')}
+                            >
+                                <Input size='compact' onBlur={onBlur} />
+                            </FormItem>
+                            <FormItem
+                                required={values.provider === 'DeepL'}
+                                name='deeplAPIURLPath'
+                                label={t('API URL Path')}
+                                caption={t('Generally, there is no need to modify this item.')}
+                            >
+                                <Input size='compact' onBlur={onBlur} />
                             </FormItem>
                         </div>
                         <div

--- a/src/common/components/Translator.tsx
+++ b/src/common/components/Translator.tsx
@@ -1240,6 +1240,10 @@ function InnerTranslator(props: IInnerTranslatorProps) {
             setShowSettings(true)
             return
         }
+        if (settings.provider === 'DeepL' && !settings.deeplAPIKey) {
+            setShowSettings(true)
+            return
+        }
     }, [props.defaultShowSettings, setShowSettings, settings])
 
     const [isOCRProcessing, setIsOCRProcessing] = useState(false)

--- a/src/common/engines/deepl.ts
+++ b/src/common/engines/deepl.ts
@@ -1,0 +1,218 @@
+import { urlJoin } from 'url-join-ts'
+import { getUniversalFetch } from '../universal-fetch'
+import { getSettings } from '../utils'
+import { AbstractEngine } from './abstract-engine'
+import { IMessageRequest, IModel } from './interfaces'
+
+const sourceLangMap: Record<string, string> = {
+    'bg': 'BG',
+    'cs': 'CS',
+    'da': 'DA',
+    'de': 'DE',
+    'el': 'EL',
+    'en': 'EN',
+    'en-US': 'EN',
+    'en-GB': 'EN',
+    'en-CA': 'EN',
+    'en-AU': 'EN',
+    'es': 'ES',
+    'et': 'ET',
+    'fi': 'FI',
+    'fr': 'FR',
+    'hu': 'HU',
+    'id': 'ID',
+    'it': 'IT',
+    'ja': 'JA',
+    'ko': 'KO',
+    'lt': 'LT',
+    'lv': 'LV',
+    'nl': 'NL',
+    'pl': 'PL',
+    'pt': 'PT',
+    'ro': 'RO',
+    'ru': 'RU',
+    'sk': 'SK',
+    'sl': 'SL',
+    'sv': 'SV',
+    'tr': 'TR',
+    'uk': 'UK',
+    'zh': 'ZH',
+    'zh-Hans': 'ZH',
+    'zh-Hant': 'ZH',
+}
+
+const targetLangMap: Record<string, string> = {
+    'bg': 'BG',
+    'cs': 'CS',
+    'da': 'DA',
+    'de': 'DE',
+    'el': 'EL',
+    'en': 'EN-US',
+    'en-US': 'EN-US',
+    'en-GB': 'EN-GB',
+    'en-CA': 'EN-US',
+    'en-AU': 'EN-US',
+    'es': 'ES',
+    'et': 'ET',
+    'fi': 'FI',
+    'fr': 'FR',
+    'hu': 'HU',
+    'id': 'ID',
+    'it': 'IT',
+    'ja': 'JA',
+    'ko': 'KO',
+    'lt': 'LT',
+    'lv': 'LV',
+    'nl': 'NL',
+    'pl': 'PL',
+    'pt': 'PT-PT',
+    'ro': 'RO',
+    'ru': 'RU',
+    'sk': 'SK',
+    'sl': 'SL',
+    'sv': 'SV',
+    'tr': 'TR',
+    'uk': 'UK',
+    'zh': 'ZH',
+    'zh-Hans': 'ZH',
+    'zh-Hant': 'ZH',
+}
+
+function mapLanguage(map: Record<string, string>, lang?: string) {
+    if (!lang) {
+        return undefined
+    }
+    if (map[lang]) {
+        return map[lang]
+    }
+    const normalized = lang.split('-')[0]
+    return map[normalized]
+}
+
+export class DeepL extends AbstractEngine {
+    async getModel(): Promise<string> {
+        return 'deepl'
+    }
+
+    async listModels(): Promise<IModel[]> {
+        return [
+            {
+                id: 'deepl',
+                name: 'DeepL Translator',
+            },
+        ]
+    }
+
+    async sendMessage(req: IMessageRequest): Promise<void> {
+        const settings = await getSettings()
+        const apiKey = settings.deeplAPIKey?.trim()
+        const meta = req.meta
+
+        if (!apiKey) {
+            req.onError('DeepL API Key is required.')
+            return
+        }
+
+        if (!meta) {
+            req.onError('DeepL provider requires translation metadata.')
+            return
+        }
+
+        const { originalText, sourceLang, targetLang, mode } = meta
+
+        if (mode !== 'translate') {
+            req.onError('DeepL API currently only supports the Translate action.')
+            return
+        }
+
+        if (!targetLang) {
+            req.onError('Target language is required for DeepL translation.')
+            return
+        }
+
+        if (!originalText) {
+            req.onError('Text to translate is empty.')
+            return
+        }
+
+        const deeplTargetLang = mapLanguage(targetLangMap, targetLang)
+        if (!deeplTargetLang) {
+            req.onError(`Unsupported target language for DeepL: ${targetLang}`)
+            return
+        }
+
+        const deeplSourceLang = mapLanguage(sourceLangMap, sourceLang)
+        if (sourceLang && !deeplSourceLang) {
+            req.onError(`Unsupported source language for DeepL: ${sourceLang}`)
+            return
+        }
+
+        const apiURL = (settings.deeplAPIURL || 'https://api-free.deepl.com').replace(/\/$/, '')
+        const apiURLPath = settings.deeplAPIURLPath || '/v2/translate'
+        const url = urlJoin(apiURL, apiURLPath)
+
+        const body = new URLSearchParams()
+        body.append('text', originalText)
+        body.append('target_lang', deeplTargetLang)
+        if (deeplSourceLang) {
+            body.append('source_lang', deeplSourceLang)
+        }
+        body.append('split_sentences', 'nonewlines')
+        body.append('preserve_formatting', '1')
+
+        const headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Authorization': `DeepL-Auth-Key ${apiKey}`,
+        }
+
+        const fetcher = getUniversalFetch()
+
+        try {
+            const resp = await fetcher(url, {
+                method: 'POST',
+                headers,
+                body: body.toString(),
+                signal: req.signal,
+            })
+
+            req.onStatusCode?.(resp.status)
+
+            if (!resp.ok) {
+                let errorMessage = `DeepL API request failed with status ${resp.status}`
+                try {
+                    const data = await resp.json()
+                    if (data?.message) {
+                        errorMessage = data.message
+                    }
+                } catch (e) {
+                    try {
+                        const text = await resp.text()
+                        if (text) {
+                            errorMessage = text
+                        }
+                    } catch {
+                        // ignore
+                    }
+                }
+                req.onError(errorMessage)
+                return
+            }
+
+            const data = await resp.json()
+            const translations: string[] = data?.translations?.map((item: { text: string }) => item.text) ?? []
+            if (translations.length === 0) {
+                req.onError('DeepL API returned an empty response.')
+                return
+            }
+
+            const content = translations.join('\n')
+            await req.onMessage({ content, role: '', isFullText: true })
+            req.onFinished('stop')
+        } catch (error) {
+            if (error instanceof Error && error.name === 'AbortError') {
+                return
+            }
+            req.onError(error instanceof Error ? error.message : 'Unknown error')
+        }
+    }
+}

--- a/src/common/engines/index.ts
+++ b/src/common/engines/index.ts
@@ -25,6 +25,8 @@ import { CohereIcon } from '@/common/components/icons/CohereIcon'
 import { Cohere } from './cohere'
 import { DeepSeekIcon } from '@/common/components/icons/DeepSeekIcon'
 import { DeepSeek } from './deepseek'
+import { DeepL } from './deepl'
+import { SiDeepl } from 'react-icons/si'
 
 export type Provider =
     | 'OpenAI'
@@ -40,6 +42,7 @@ export type Provider =
     | 'ChatGLM'
     | 'Cohere'
     | 'DeepSeek'
+    | 'DeepL'
 
 export const engineIcons: Record<Provider, IconType> = {
     OpenAI: RiOpenaiFill,
@@ -55,6 +58,7 @@ export const engineIcons: Record<Provider, IconType> = {
     ChatGLM: ChatGLMIcon,
     Cohere: CohereIcon,
     DeepSeek: DeepSeekIcon,
+    DeepL: SiDeepl,
 }
 
 export const providerToEngine: Record<Provider, { new (): IEngine }> = {
@@ -71,6 +75,7 @@ export const providerToEngine: Record<Provider, { new (): IEngine }> = {
     ChatGLM: ChatGLM,
     Cohere: Cohere,
     DeepSeek: DeepSeek,
+    DeepL: DeepL,
 }
 
 export function getEngine(provider: Provider): IEngine {

--- a/src/common/engines/interfaces.ts
+++ b/src/common/engines/interfaces.ts
@@ -9,6 +9,15 @@ export interface IMessage {
     content: string
 }
 
+export interface IMessageRequestMeta {
+    originalText?: string
+    sourceLang?: string
+    targetLang?: string
+    mode?: string
+    writing?: boolean
+    selectedWord?: string
+}
+
 export interface IMessageRequest {
     rolePrompt: string
     commandPrompt: string
@@ -17,6 +26,7 @@ export interface IMessageRequest {
     onFinished: (reason: string) => void
     onStatusCode?: (statusCode: number) => void
     signal: AbortSignal
+    meta?: IMessageRequestMeta
 }
 
 export interface IEngine {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -72,6 +72,9 @@ export interface ISettings {
     geminiAPIModel: string
     moonshotAPIKey: string
     moonshotAPIModel: string
+    deeplAPIKey: string
+    deeplAPIURL: string
+    deeplAPIURLPath: string
     deepSeekAPIKey: string
     deepSeekAPIModel: string
     autoTranslate: boolean

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -57,6 +57,9 @@ const settingKeys: Record<keyof ISettings, number> = {
     miniMaxAPIModel: 1,
     moonshotAPIKey: 1,
     moonshotAPIModel: 1,
+    deeplAPIKey: 1,
+    deeplAPIURL: 1,
+    deeplAPIURLPath: 1,
     geminiAPIURL: 1,
     geminiAPIKey: 1,
     geminiAPIModel: 1,
@@ -130,6 +133,15 @@ export async function getSettings(): Promise<ISettings> {
     }
     if (!settings.apiModel) {
         settings.apiModel = defaultAPIModel
+    }
+    if (!settings.deeplAPIKey) {
+        settings.deeplAPIKey = ''
+    }
+    if (!settings.deeplAPIURL) {
+        settings.deeplAPIURL = 'https://api-free.deepl.com'
+    }
+    if (!settings.deeplAPIURLPath) {
+        settings.deeplAPIURLPath = '/v2/translate'
     }
     if (!settings.provider) {
         settings.provider = defaultProvider


### PR DESCRIPTION
## Summary
- add a DeepL engine that translates via the REST API with language mapping and error handling
- expose DeepL as a selectable provider with settings to capture its API key and endpoint configuration
- propagate translation metadata/defaults so DeepL receives language context and prompt users if the key is missing

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6f1c9d7c832aa30ee92f041e8249